### PR TITLE
Update kube api resources

### DIFF
--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -99,8 +100,8 @@ spec:
           serviceName: repo-supervisor
           servicePort: 80
         path: /
----
 kind: ConfigMap
+---
 apiVersion: v1
 metadata:
   name: supervisor-config-file

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -100,8 +100,8 @@ spec:
           serviceName: repo-supervisor
           servicePort: 80
         path: /
-kind: ConfigMap
 ---
+kind: ConfigMap
 apiVersion: v1
 metadata:
   name: supervisor-config-file

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -1,29 +1,52 @@
----
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
+  labels:
+    app: repo-supervisor
   name: repo-supervisor
   namespace: cloud
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 2
   revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: repo-supervisor
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: repo-supervisor
     spec:
       containers:
-      - name: repo-supervisor
-        image: registry.usw.co/uswitch/repo-supervisor:{{ .Env.DRONE_COMMIT }}
-        ports:
-        - containerPort: 7070
-        env:
+      - env:
         - name: HOST
-          value: "0.0.0.0"
+          value: 0.0.0.0
         - name: GITHUB_TOKEN
           value: {{ .Env.GITHUB_TOKEN }}
         - name: JWT_SECRET
           value: {{ .Env.GITHUB_TOKEN }}
+        image: registry.usw.co/uswitch/repo-supervisor:{{ .Env.DRONE_COMMIT }}
+        imagePullPolicy: IfNotPresent
+        name: repo-supervisor
+        ports:
+        - containerPort: 7070
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256M
+          requests:
+            cpu: 10m
+            memory: 128M
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: ssl-certs-host
@@ -31,21 +54,21 @@ spec:
         - mountPath: /opt/repo-supervisor/.config.json
           name: supervisor-config-file
           subPath: .config.json
-        resources:
-          requests:
-            memory: 128M
-            cpu: 10m
-          limits:
-            memory: 256M
-            cpu: 100m
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
       volumes:
       - hostPath:
           path: /usr/share/ca-certificates
+          type: ""
         name: ssl-certs-host
-      - name: supervisor-config-file
-        configMap:
+      - configMap:
+          defaultMode: 420
           name: supervisor-config-file
-
+        name: supervisor-config-file
+status: {}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Hello there,

In preparation for upgrading to Kubernetes v1.16, (note: we have recently upgraded to v1.13), we have made changes to some of your kubernetes manifests.

The v1.16 release will stop serving a number of deprecated API versions in favor of newer and more stable API versions. For us, this means DaemonSet, Deployment, StatefulSet, and ReplicaSet all need to be updated to be using apps/v1. 

Any manifests referencing deprecated APIs (extensions/v1beta1, apps/v1beta1, or apps/v1beta2) will need to be updated before we roll out Kubernetes v1.16 in order to continue to work.

To lessen the work, we have gone through all the repositories and updated the resource APIs for you. We have pushed any changes to the `machinegun-<randomstring>` branch so feel free to make any changes and/or updates to this branch.

Note: If you are making changes, specifically to Deployments, make sure that you leave the Selector field under the Spec section as this is now mandatory.

During the conversion process, resources may have been updated with defaults and/or changed API fields. The defaults that you see were already in use but are now explicitly set.

Cosmetic changes may have also occurred, for example API fields may have moved around and comments may have been removed. Feel free to move API fields back to their original positions and re-add comments.

We appreciate your assistance in ensuring a smooth transition to Kubernetes v1.16.

If you have any questions, message in #cloud-infrastructure.

Thanks,

Cloud Team